### PR TITLE
Xpath processing: preload yang.Entry with structs

### DIFF
--- a/modelplugin/testdevice-2.0.0/testdevice_2_0_0/xpath_test.go
+++ b/modelplugin/testdevice-2.0.0/testdevice_2_0_0/xpath_test.go
@@ -15,6 +15,7 @@
 package testdevice_2_0_0
 
 import (
+	"fmt"
 	"github.com/antchfx/xpath"
 	"github.com/onosproject/config-models/pkg/xpath/navigator"
 	"github.com/stretchr/testify/assert"
@@ -22,7 +23,39 @@ import (
 	"testing"
 )
 
-func Test_XPath(t *testing.T) {
+func Test_XPathQuery(t *testing.T) {
+	expr, err := xpath.Compile("/t1:cont1a/*")
+	assert.NoError(t, err)
+	assert.NotNil(t, expr)
+
+	sampleConfig, err := ioutil.ReadFile("../testdata/sample-testdevice2-config.json")
+	if err != nil {
+		assert.NoError(t, err)
+	}
+	device := new(Device)
+
+	schema, err := Schema()
+	if err := schema.Unmarshal(sampleConfig, device); err != nil {
+		assert.NoError(t, err)
+	}
+	schema.Root = device
+	assert.NotNil(t, device)
+	ynn := navigator.NewYangNodeNavigator(schema.RootSchema(), device)
+	assert.NotNil(t, ynn)
+
+	//evaluated := expr.Evaluate(ynn)
+	//assert.NotNil(t, evaluated)
+
+	iter := expr.Select(ynn)
+	for iter.MoveNext() {
+		fmt.Printf("Iter Value: %s: %s\n",
+			iter.Current().LocalName(), iter.Current().Value())
+	}
+}
+
+
+
+func Test_XPathNodeNavigation(t *testing.T) {
 
 	sampleConfig, err := ioutil.ReadFile("../testdata/sample-testdevice2-config.json")
 	if err != nil {
@@ -41,7 +74,7 @@ func Test_XPath(t *testing.T) {
 	assert.Equal(t, xpath.ElementNode, ynn.NodeType())
 	assert.Equal(t, "device", ynn.LocalName())
 	assert.Equal(t, "", ynn.Prefix())
-	assert.Equal(t, "", ynn.Value())
+	assert.Equal(t, "value of device", ynn.Value())
 
 	assert.True(t, ynn.MoveToChild())
 	assert.Equal(t, "cont1a", ynn.LocalName())
@@ -55,7 +88,7 @@ func Test_XPath(t *testing.T) {
 
 	assert.True(t, ynn.MoveToChild())
 	assert.Equal(t, "leaf2a", ynn.LocalName())
-	assert.Equal(t, xpath.TextNode, ynn.NodeType())
+	assert.Equal(t, xpath.ElementNode, ynn.NodeType())
 	assert.Equal(t, "t1", ynn.Prefix())
 	assert.Equal(t, "1", ynn.Value())
 
@@ -63,7 +96,7 @@ func Test_XPath(t *testing.T) {
 
 	assert.True(t, ynn.MoveToNext())
 	assert.Equal(t, "leaf2b", ynn.LocalName())
-	assert.Equal(t, xpath.TextNode, ynn.NodeType())
+	assert.Equal(t, xpath.ElementNode, ynn.NodeType())
 	assert.Equal(t, "t1", ynn.Prefix())
 	assert.Equal(t, "0.4321", ynn.Value())
 
@@ -72,17 +105,17 @@ func Test_XPath(t *testing.T) {
 	assert.Equal(t, "leaf2e", ynn.LocalName())
 	assert.Equal(t, xpath.ElementNode, ynn.NodeType()) // Leaf list
 	assert.Equal(t, "t1", ynn.Prefix())
-	assert.Equal(t, "", ynn.Value())
+	assert.Equal(t, "[5 4 3 2 1]", ynn.Value())
 
 	assert.True(t, ynn.MoveToNext())
 	assert.Equal(t, "leaf2f", ynn.LocalName())
-	assert.Equal(t, xpath.TextNode, ynn.NodeType())
+	assert.Equal(t, xpath.ElementNode, ynn.NodeType())
 	assert.Equal(t, "t1", ynn.Prefix())
 	assert.Equal(t, "dGhpcyBpcyBhIHRlc3QgdGVzdAo=", ynn.Value())
 
 	assert.True(t, ynn.MoveToNext())
 	assert.Equal(t, "leaf2g", ynn.LocalName())
-	assert.Equal(t, xpath.TextNode, ynn.NodeType())
+	assert.Equal(t, xpath.ElementNode, ynn.NodeType())
 	assert.Equal(t, "t1", ynn.Prefix())
 	assert.Equal(t, "true", ynn.Value())
 
@@ -91,13 +124,13 @@ func Test_XPath(t *testing.T) {
 
 	assert.True(t, ynn.MoveToPrevious())
 	assert.Equal(t, "leaf2f", ynn.LocalName())
-	assert.Equal(t, xpath.TextNode, ynn.NodeType())
+	assert.Equal(t, xpath.ElementNode, ynn.NodeType())
 	assert.Equal(t, "t1", ynn.Prefix())
 	assert.Equal(t, "dGhpcyBpcyBhIHRlc3QgdGVzdAo=", ynn.Value())
 
 	assert.True(t, ynn.MoveToFirst())
 	assert.Equal(t, "leaf2a", ynn.LocalName())
-	assert.Equal(t, xpath.TextNode, ynn.NodeType())
+	assert.Equal(t, xpath.ElementNode, ynn.NodeType())
 	assert.Equal(t, "t1", ynn.Prefix())
 	assert.Equal(t, "1", ynn.Value())
 
@@ -105,11 +138,11 @@ func Test_XPath(t *testing.T) {
 	assert.Equal(t, "cont2a", ynn.LocalName())
 	assert.Equal(t, xpath.ElementNode, ynn.NodeType())
 	assert.Equal(t, "t1", ynn.Prefix())
-	assert.Equal(t, "", ynn.Value())
+	assert.Equal(t, "value of cont2a", ynn.Value())
 
 	assert.True(t, ynn.MoveToNext())
 	assert.Equal(t, "leaf1a", ynn.LocalName())
-	assert.Equal(t, xpath.TextNode, ynn.NodeType())
+	assert.Equal(t, xpath.ElementNode, ynn.NodeType())
 	assert.Equal(t, "t1", ynn.Prefix())
 	assert.Equal(t, "leaf1aval", ynn.Value())
 
@@ -126,13 +159,13 @@ func Test_XPath(t *testing.T) {
 
 	assert.True(t, ynn.MoveToNext())
 	assert.Equal(t, "rx-power", ynn.LocalName())
-	assert.Equal(t, xpath.TextNode, ynn.NodeType())
+	assert.Equal(t, xpath.ElementNode, ynn.NodeType())
 	assert.Equal(t, "t1", ynn.Prefix())
 	assert.Equal(t, "25", ynn.Value())
 
 	assert.True(t, ynn.MoveToNext())
 	assert.Equal(t, "tx-power", ynn.LocalName())
-	assert.Equal(t, xpath.TextNode, ynn.NodeType())
+	assert.Equal(t, xpath.ElementNode, ynn.NodeType())
 	assert.Equal(t, "t1", ynn.Prefix())
 	assert.Equal(t, "5", ynn.Value())
 
@@ -156,13 +189,13 @@ func Test_XPath(t *testing.T) {
 
 	assert.True(t, ynn.MoveToNext())
 	assert.Equal(t, "rx-power", ynn.LocalName())
-	assert.Equal(t, xpath.TextNode, ynn.NodeType())
+	assert.Equal(t, xpath.ElementNode, ynn.NodeType())
 	assert.Equal(t, "t1", ynn.Prefix())
 	assert.Equal(t, "26", ynn.Value())
 
 	assert.True(t, ynn.MoveToNext())
 	assert.Equal(t, "tx-power", ynn.LocalName())
-	assert.Equal(t, xpath.TextNode, ynn.NodeType())
+	assert.Equal(t, xpath.ElementNode, ynn.NodeType())
 	assert.Equal(t, "t1", ynn.Prefix())
 	assert.Equal(t, "6", ynn.Value())
 
@@ -206,7 +239,7 @@ func Test_XPath(t *testing.T) {
 
 	assert.True(t, ynn.MoveToNext())
 	assert.Equal(t, "leaf3c", ynn.LocalName())
-	assert.Equal(t, xpath.TextNode, ynn.NodeType())
+	assert.Equal(t, xpath.ElementNode, ynn.NodeType())
 	assert.Equal(t, "t1", ynn.Prefix())
 	assert.Equal(t, "3c 10-20 test", ynn.Value())
 
@@ -233,13 +266,13 @@ func Test_XPath(t *testing.T) {
 
 	assert.True(t, ynn.MoveToNext())
 	assert.Equal(t, "leaf3c", ynn.LocalName())
-	assert.Equal(t, xpath.TextNode, ynn.NodeType())
+	assert.Equal(t, xpath.ElementNode, ynn.NodeType())
 	assert.Equal(t, "t1", ynn.Prefix())
 	assert.Equal(t, "3c 11-20 test", ynn.Value())
 
 	assert.True(t, ynn.MoveToNext())
 	assert.Equal(t, "leaf3d", ynn.LocalName())
-	assert.Equal(t, xpath.TextNode, ynn.NodeType())
+	assert.Equal(t, xpath.ElementNode, ynn.NodeType())
 	assert.Equal(t, "t1", ynn.Prefix())
 	assert.Equal(t, "IDTYPE2", ynn.Value())
 

--- a/pkg/xpath/navigator/navigator.go
+++ b/pkg/xpath/navigator/navigator.go
@@ -24,38 +24,150 @@ import (
 	"strings"
 )
 
+const (
+	goStruct        = "gostruct"
+	orderedAttrList = "orderedattrlist"
+)
+
 // YangNodeNavigator - implements xpath.NodeNavigator
 type YangNodeNavigator struct {
-	root, curr     *yang.Entry
-	currKeys       []string
-	currListKeys   []string
-	currIdx        int
-	currListIdx    interface{}
-	deviceRoot     interface{}
-	currValueStack []interface{}
+	root, curr *yang.Entry
 }
 
 func NewYangNodeNavigator(root *yang.Entry, device interface{}) xpath.NodeNavigator {
-	currKeys, listKeys := orderKeys(root.Dir, root.Key)
-
 	nav := &YangNodeNavigator{
-		root:           root,
-		curr:           root,
-		currKeys:       currKeys,
-		currListKeys:   listKeys,
-		deviceRoot:     device,
-		currValueStack: []interface{}{device},
+		root: root,
+		curr: root,
 	}
+
+	addGoStructToYangEntry(root, device)
+
 	return nav
+}
+
+func addGoStructToYangEntry(dir *yang.Entry, yangStruct interface{}) []string {
+	if dir.Annotation == nil {
+		dir.Annotation = make(map[string]interface{})
+	}
+	// Create a new entry per list index
+	if dir.IsList() {
+		listKeys := make([]string, 0)
+		mapIter := reflect.ValueOf(yangStruct).MapRange()
+		for mapIter.Next() {
+			orderedKeys := make([]string, 0, len(dir.Dir))
+			newDir := deepCopyDir(dir)
+			if newDir.Annotation == nil {
+				newDir.Annotation = make(map[string]interface{})
+			}
+			for k, v := range newDir.Dir {
+				processStruct(mapIter.Value(), k, v)
+				v.Parent = newDir
+				orderedKeys = append(orderedKeys, k)
+			}
+			newDir.Annotation[goStruct] = mapIter.Value().Interface()
+			listKey := fmt.Sprintf("%s__%v", dir.Name, mapIter.Key().Interface())
+			sort.Strings(orderedKeys)
+			newDir.Annotation[orderedAttrList] = orderedKeys
+			newDir.Annotation[dir.Name] = fmt.Sprint(mapIter.Key().Interface())
+			dir.Parent.Dir[listKey] = newDir
+			listKeys = append(listKeys, listKey)
+		}
+		return listKeys
+	}
+	// Else is a struct
+	dir.Annotation[goStruct] = yangStruct
+	if dir.IsLeaf() {
+		return []string{dir.Name}
+	}
+	orderedKeys := make([]string, 0, len(dir.Dir))
+	for k, v := range dir.Dir {
+		structVal := reflect.ValueOf(yangStruct)
+		switch structVal.Kind() {
+		case reflect.Ptr:
+			keysAdded := processStruct(structVal, k, v)
+			orderedKeys = append(orderedKeys, keysAdded...)
+		default:
+			panic(fmt.Errorf("unhandled kind %s", structVal.Kind().String()))
+		}
+	}
+	if len(orderedKeys) > 0 {
+		sort.Strings(orderedKeys)
+		dir.Annotation[orderedAttrList] = orderedKeys
+	}
+	return []string{dir.Name}
+}
+
+func processStruct(structVal reflect.Value, dirName string, dirValue *yang.Entry) []string {
+	for i := 0; i < structVal.Elem().Type().NumField(); i++ {
+		fieldPathName := structVal.Elem().Type().Field(i).Tag.Get("path")
+		if fieldPathName != dirName {
+			continue
+		}
+		fieldName := structVal.Elem().Type().Field(i).Name
+		val := structVal.Elem().FieldByName(fieldName)
+		if !val.IsZero() {
+			return addGoStructToYangEntry(dirValue, val.Interface()) //Recursive
+		}
+		return nil
+	}
+	return nil
+}
+
+func deepCopyDir(dir *yang.Entry) *yang.Entry {
+	newDir := &yang.Entry{
+		Parent:      dir.Parent,
+		Node:        dir.Node,
+		Name:        dir.Name,
+		Description: dir.Description,
+		Default:     dir.Default,
+		Units:       dir.Units,
+		Errors:      dir.Errors,
+		Kind:        dir.Kind,
+		Config:      dir.Config,
+		Prefix:      dir.Prefix,
+		Mandatory:   dir.Mandatory,
+		Dir:         nil,
+		Key:         dir.Key,
+		Type:        dir.Type,
+		Exts:        dir.Exts,
+		ListAttr:    dir.ListAttr,
+		RPC:         dir.RPC,
+		Identities:  dir.Identities,
+		Augments:    dir.Augments,
+		Augmented:   dir.Augmented,
+		Deviations:  dir.Deviations,
+		Deviate:     dir.Deviate,
+		Uses:        dir.Uses,
+		Extra:       dir.Extra,
+		Annotation:  nil,
+	}
+
+	if dir.Dir != nil {
+		newDir.Dir = make(map[string]*yang.Entry)
+		for k, v := range dir.Dir {
+			newDir.Dir[k] = deepCopyDir(v)
+		}
+	}
+
+	if dir.Annotation != nil {
+		newDir.Annotation = make(map[string]interface{})
+		for k, v := range dir.Annotation {
+			if k != goStruct && k != orderedAttrList {
+				newDir.Annotation[k] = v
+			}
+		}
+	}
+
+	return newDir
 }
 
 // NodeType returns the XPathNodeType of the current node.
 func (x *YangNodeNavigator) NodeType() xpath.NodeType {
-	if x.curr.IsLeaf() && x.curr.Parent.IsList() && strings.Contains(x.curr.Parent.Key, x.curr.Name) {
+	if x.curr.Parent != nil && x.curr.Parent.IsList() && strings.Contains(x.curr.Parent.Key, x.curr.Name) {
 		return xpath.AttributeNode
 	}
 	if x.curr.IsLeaf() {
-		return xpath.TextNode
+		return xpath.ElementNode
 	}
 	if x.curr.IsContainer() || x.curr.IsLeafList() || x.curr.IsList() {
 		return xpath.ElementNode
@@ -80,54 +192,89 @@ func (x *YangNodeNavigator) Prefix() string {
 // Value gets the value of current node.
 func (x *YangNodeNavigator) Value() string {
 	if x.curr.IsLeaf() {
-		val := reflect.ValueOf(x.currValueStack[len(x.currValueStack)-1])
-		switch k := val.Kind(); k {
-		case reflect.Slice:
-			switch val.Type().Name() {
-			case "Binary":
-				srcBytes := make([]byte, 0, val.Len())
-				for i := 0; i < val.Len(); i++ {
-					valI := val.Index(i).Interface()
-					srcBytes = append(srcBytes, valI.(uint8))
+		value, ok := x.curr.Annotation[goStruct]
+		if ok {
+			switch vt := value.(type) {
+			case *uint:
+				return fmt.Sprint(*(vt))
+			case *uint8:
+				return fmt.Sprint(*(vt))
+			case *uint16:
+				return fmt.Sprint(*(vt))
+			case *uint32:
+				return fmt.Sprint(*(vt))
+			case *uint64:
+				return fmt.Sprint(*(vt))
+			case *int:
+				return fmt.Sprint(*(vt))
+			case *int8:
+				return fmt.Sprint(*(vt))
+			case *int16:
+				return fmt.Sprint(*(vt))
+			case *int32:
+				return fmt.Sprint(*(vt))
+			case *int64:
+				return fmt.Sprint(*(vt))
+			case *float64:
+				return fmt.Sprint(*(vt))
+			case *bool:
+				return fmt.Sprint(*(vt))
+			case *string:
+				return *(vt)
+			default:
+				valueReflected := reflect.ValueOf(value)
+				switch valueReflected.Kind() {
+				case reflect.Slice: // Most likely Binary
+					bytes := valueReflected.Bytes()
+					return base64.StdEncoding.EncodeToString(bytes)
+				case reflect.Int64: // Most likely a YANG Identity
+					ytype := x.curr.Type
+					if ytype != nil {
+						base := ytype.IdentityBase
+						if base != nil && len(base.Values) > 0 {
+							return base.Values[valueReflected.Int()-1].Name
+						}
+					}
+					return fmt.Sprint(valueReflected.Int())
+				default:
+					panic(fmt.Errorf("unhandled value type %s", valueReflected.Kind()))
 				}
-				return base64.StdEncoding.EncodeToString(srcBytes)
 			}
-			return fmt.Sprint(val.Interface())
-		case reflect.Struct:
-			return fmt.Sprint(val.Elem().Interface())
-		case reflect.Ptr:
-			return fmt.Sprint(val.Elem().Interface())
-		case reflect.Int64: // For identities (enumerations)
-			if x.curr.Type != nil && x.curr.Type.IdentityBase != nil &&
-				len(x.curr.Type.IdentityBase.Values) > int(val.Int()-1) {
-				return x.curr.Type.IdentityBase.Values[val.Int()-1].Name
+		}
+	} else if x.curr.IsLeafList() {
+		value, ok := x.curr.Annotation[goStruct]
+		if ok {
+			switch value.(type) {
+			case []int16:
+				return fmt.Sprint(value)
+			default:
+				panic(fmt.Errorf("unhandled leaf list type"))
 			}
-			return fmt.Sprintf("%d", val.Int())
-		default:
-			fmt.Printf("unexpected kind %s\n", k)
 		}
 	}
-	return ""
+
+	return fmt.Sprintf("value of %s", x.curr.Name)
 }
 
 // Copy does a deep copy of the YangNodeNavigator and all its components.
 func (x *YangNodeNavigator) Copy() xpath.NodeNavigator {
-	return nil
+	copy := YangNodeNavigator{
+		root: x.root,
+		curr: x.curr,
+	}
+
+	return &copy
 }
 
 // MoveToRoot moves the YangNodeNavigator to the root node of the current node.
 func (x *YangNodeNavigator) MoveToRoot() {
 	x.curr = x.root
-	x.currKeys, x.currListKeys = orderKeys(x.curr.Dir, x.curr.Key)
 }
 
 // MoveToParent moves the YangNodeNavigator to the parent node of the current node.
 func (x *YangNodeNavigator) MoveToParent() bool {
 	if x.curr.Parent != nil {
 		x.curr = x.curr.Parent
-		x.currKeys, x.currListKeys = orderKeys(x.curr.Parent.Dir, x.curr.Key)
-		x.currIdx = findKeyIndex(x.currKeys, x.curr.Name)
-		x.currValueStack = x.currValueStack[:len(x.currValueStack)-1]
 		return true
 	}
 	return false
@@ -140,32 +287,18 @@ func (x *YangNodeNavigator) MoveToNextAttribute() bool {
 
 // MoveToChild moves the YangNodeNavigator to the first child node of the current node.
 func (x *YangNodeNavigator) MoveToChild() bool {
-	if x.curr.IsList() {
-		x.currKeys, x.currListKeys = orderKeys(x.curr.Dir, x.curr.Key)
-		x.currIdx = -len(x.currListKeys)
-		currValue, currListIdx := listEntryFromPathTag(x.currValueStack, x.currListIdx, false)
-		x.currListIdx = currListIdx
-		x.currValueStack[len(x.currValueStack)-1] = currValue // Replace last entry
-		x.currValueStack = append(x.currValueStack, fieldFromPathTag(x.currValueStack, x.currListKeys[0]))
-		x.curr = x.curr.Dir[x.currListKeys[0]] // TODO: don't use fixed value
-		return true
-	}
 	if !x.curr.IsLeaf() && x.curr.Dir != nil {
-		currKeys, _ := orderKeys(x.curr.Dir, x.curr.Key)
-		for i := 0; i < len(x.currKeys); i++ {
+		currKeys := getOrderedKeys(x.curr.Annotation)
+		for i := 0; i < len(currKeys); i++ {
 			curr, ok := x.curr.Dir[currKeys[i]]
 			if !ok {
 				continue
 			}
-			valueObject := fieldFromPathTag(x.currValueStack, curr.Name)
+			valueObject := getGoStruct(x.curr.Annotation)
 			if valueObject == nil {
 				continue
 			}
 			x.curr = curr
-			if !x.curr.IsLeaf() {
-				x.currKeys, x.currListKeys = orderKeys(x.curr.Dir, x.curr.Key)
-			}
-			x.currValueStack = append(x.currValueStack, valueObject)
 			return true
 		}
 	}
@@ -174,19 +307,15 @@ func (x *YangNodeNavigator) MoveToChild() bool {
 
 // MoveToFirst moves the YangNodeNavigator to the first sibling node of the current node.
 func (x *YangNodeNavigator) MoveToFirst() bool {
-	for i := 0; i < len(x.currKeys); i++ {
-		// The first item might not have a value
-		currIdx := i
-		curr := x.curr.Parent.Dir[x.currKeys[currIdx]]
-		// First check it has a value
-		currValueStack := x.currValueStack[:len(x.currValueStack)-1]
-		newVal := fieldFromPathTag(currValueStack, curr.Name)
-		if newVal != nil {
-			x.currIdx = currIdx
-			x.curr = curr
-			x.currValueStack = x.currValueStack[:len(x.currValueStack)-1]
-			x.currValueStack = append(x.currValueStack, newVal)
-			return true
+	parent := x.curr.Parent
+	if parent != nil {
+		orderedKeys := getOrderedKeys(x.curr.Parent.Annotation)
+		curr, ok := parent.Dir[orderedKeys[0]]
+		if ok {
+			if _, structok := curr.Annotation[goStruct]; structok {
+				x.curr = curr
+				return true
+			}
 		}
 	}
 	return false
@@ -194,64 +323,20 @@ func (x *YangNodeNavigator) MoveToFirst() bool {
 
 // MoveToNext moves the YangNodeNavigator to the next sibling node of the current node.
 func (x *YangNodeNavigator) MoveToNext() bool {
-	if x.curr.IsList() { // This could be a continuation from a previous list entry
-		currValueStack := x.currValueStack[:len(x.currValueStack)-1]
-		listParent := fieldFromPathTag(currValueStack, x.curr.Name)
-		currValueStack = append(currValueStack, listParent)
-		newVal, nextIdx := listEntryFromPathTag(currValueStack, x.currListIdx, true)
-		if newVal != nil {
-			x.currValueStack[len(x.currValueStack)-1] = listParent
-			x.currListIdx = nextIdx
-			x.currKeys, _ = orderKeys(x.curr.Dir, "")
-			x.currIdx = -len(x.currListKeys)
-			return true
-		}
-	}
-	// handle any extra list keys values if they exist
-	if x.currIdx < -1 {
-		x.currIdx++
-		listIdx := x.currIdx + len(x.currListKeys)
-		x.curr = x.curr.Parent.Dir[x.currListKeys[listIdx]]
-		// First check it has a value
-		currValueStack := x.currValueStack[:len(x.currValueStack)-1]
-		nextIdx := fieldFromPathTag(currValueStack, x.curr.Name)
-		currValueStack = append(currValueStack, nextIdx)
-		x.currValueStack = currValueStack
-		return true
-	}
-
-	for i := 0; i < len(x.currKeys); i++ {
-		currIdx := x.currIdx + i + 1
-		if currIdx > len(x.currKeys)-1 {
-			return false
-		}
-		curr := x.curr.Parent.Dir[x.currKeys[currIdx]]
-		// First check it has a value
-		currValueStack := x.currValueStack[:len(x.currValueStack)-1]
-
-		// Look first for a next entry in a list
-		if curr.IsList() {
-			listParent := fieldFromPathTag(currValueStack, curr.Name)
-			currValueStack = append(currValueStack, listParent)
-			newVal, nextIdx := listEntryFromPathTag(currValueStack, x.currListIdx, true)
-			if newVal != nil {
-				x.curr = curr
-				x.currValueStack[len(x.currValueStack)-1] = listParent // Replace last entry
-				x.currListIdx = nextIdx
-				x.currKeys, _ = orderKeys(x.curr.Dir, "")
-				x.currIdx = -len(x.currListKeys)
-				return true
-			} else {
-				return false
+	parent := x.curr.Parent
+	if parent != nil {
+		currName := x.curr.Name
+		nextKey := getNextKey(x.curr.Annotation, parent.Annotation, currName)
+		for ; nextKey != ""; nextKey = getNextKey(x.curr.Annotation, parent.Annotation, currName) {
+			curr, ok := parent.Dir[nextKey]
+			if ok {
+				if _, structok := curr.Annotation[goStruct]; structok {
+					x.curr = curr
+					return true
+				} else {
+					currName = nextKey
+				}
 			}
-		}
-		newVal := fieldFromPathTag(currValueStack, curr.Name)
-		if newVal != nil {
-			x.currIdx = currIdx
-			x.curr = curr
-			x.currValueStack = x.currValueStack[:len(x.currValueStack)-1]
-			x.currValueStack = append(x.currValueStack, newVal)
-			return true
 		}
 	}
 	return false
@@ -259,21 +344,20 @@ func (x *YangNodeNavigator) MoveToNext() bool {
 
 // MoveToPrevious moves the YangNodeNavigator to the previous sibling node of the current node.
 func (x *YangNodeNavigator) MoveToPrevious() bool {
-	for i := 0; i < len(x.currKeys); i++ {
-		currIdx := x.currIdx - i - 1
-		if currIdx < 0 {
-			return false
-		}
-		curr := x.curr.Parent.Dir[x.currKeys[currIdx]]
-		// First check it has a value
-		currValueStack := x.currValueStack[:len(x.currValueStack)-1]
-		newVal := fieldFromPathTag(currValueStack, curr.Name)
-		if newVal != nil {
-			x.currIdx = currIdx
-			x.curr = curr
-			x.currValueStack = x.currValueStack[:len(x.currValueStack)-1]
-			x.currValueStack = append(x.currValueStack, newVal)
-			return true
+	parent := x.curr.Parent
+	if parent != nil {
+		currName := x.curr.Name
+		prevKey := getPreviousKey(parent.Annotation, currName)
+		for ; prevKey != ""; prevKey = getPreviousKey(parent.Annotation, currName) {
+			curr, ok := parent.Dir[prevKey]
+			if ok {
+				if _, structok := curr.Annotation[goStruct]; structok {
+					x.curr = curr
+					return true
+				} else {
+					currName = prevKey
+				}
+			}
 		}
 	}
 	return false
@@ -284,109 +368,51 @@ func (x *YangNodeNavigator) MoveTo(dest xpath.NodeNavigator) bool {
 	return false
 }
 
-func orderKeys(dir map[string]*yang.Entry, listKeysStr string) ([]string, []string) {
-	currKeys := make([]string, 0, len(dir))
-	var listKeys []string
-	if listKeysStr == "" {
-		listKeys = make([]string, 0)
-	} else {
-		listKeys = strings.Split(listKeysStr, " ")
-	}
-outerLoop:
-	for k := range dir {
-		for _, l := range listKeys {
-			if l == k {
-				continue outerLoop
-			}
+func getOrderedKeys(annotation map[string]interface{}) []string {
+	orderedKeys, ok := annotation[orderedAttrList]
+	if ok {
+		strArray, ok := orderedKeys.([]string)
+		if ok {
+			return strArray
 		}
-		currKeys = append(currKeys, k)
-	}
-	sort.Strings(currKeys)
-
-	return currKeys, listKeys
-}
-
-func findKeyIndex(keys []string, name string) int {
-	for i, k := range keys {
-		if k == name {
-			return i
-		}
-	}
-	return -1
-}
-
-func fieldFromPathTag(currValue []interface{}, tag string) interface{} {
-	topCurrValue := currValue[len(currValue)-1]
-	if topCurrValue == nil {
-		return nil
-	}
-	currValueType := reflect.TypeOf(topCurrValue).Elem()
-	for i := 0; i < currValueType.NumField(); i++ {
-		if currValueType.Field(i).Tag.Get("path") == tag {
-			fieldName := currValueType.Field(i).Name
-			val := reflect.ValueOf(topCurrValue).Elem().FieldByName(fieldName)
-			if val.IsValid() {
-				if !val.IsZero() {
-					return val.Interface()
-				}
-			}
-			return nil
-		}
+		panic(fmt.Errorf("unexpected type for orderedKeys: %v", orderedKeys))
 	}
 	return nil
 }
 
-func listEntryFromPathTag(currValueStack []interface{}, index interface{}, next bool) (interface{}, interface{}) {
-	topCurrValue := currValueStack[len(currValueStack)-1]
-	currValueType := reflect.TypeOf(topCurrValue)
-	topCurrValueType := reflect.ValueOf(topCurrValue)
-	switch currValueType.Kind() {
-	case reflect.Map:
-		mapKeys := topCurrValueType.MapKeys()
-		sort.Slice(mapKeys, func(i, j int) bool {
-			return mapKeys[i].String() < mapKeys[j].String()
-		})
-		gotIndex := false
-		for _, k := range mapKeys {
-			if index != nil && reflect.TypeOf(index).Kind() == k.Kind() {
-				if k.Interface() == index {
-					gotIndex = true
-					if next {
-						continue
-					} else {
-						return topCurrValueType.MapIndex(k).Interface(), k.Interface()
-					}
-				}
-				if gotIndex {
-					return topCurrValueType.MapIndex(k).Interface(), k.Interface()
-				}
-			} else {
-				return topCurrValueType.MapIndex(k).Interface(), k.Interface()
+func getNextKey(selfAnnot map[string]interface{}, parentAnnot map[string]interface{}, key string) string {
+	listEntryName, ok := selfAnnot[key]
+	orderedKeys := getOrderedKeys(parentAnnot)
+	for i, k := range orderedKeys {
+		if k == key {
+			if i < len(orderedKeys)-1 {
+				return orderedKeys[i+1]
+			}
+		} else if ok && k == fmt.Sprintf("%s__%s", key, listEntryName) {
+			if i < len(orderedKeys)-1 {
+				return orderedKeys[i+1]
 			}
 		}
-	case reflect.Ptr:
-		topParentValue := currValueStack[len(currValueStack)-2]
-		fmt.Println(topParentValue)
-
-		// Need to build up a new Key object for the next instance
-		// This happens where there is more than one key in a list
-		// Then rather than using the native type(s) a struct is created
-		// Here we know what that key struct type is from prior "index"
-		indexType := reflect.TypeOf(index)
-		newKeyValue := reflect.New(indexType) // Ptr
-		for i := 0; i < indexType.NumField(); i++ {
-			sfKey := indexType.FieldByIndex([]int{i})
-			switch sfKey.Type.Kind() {
-			case reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint:
-				fieldI := topCurrValueType.Elem().FieldByIndex([]int{i}).Elem().Uint()
-				newKeyValue.Elem().FieldByIndex([]int{i}).SetUint(fieldI)
-			default:
-				panic(fmt.Errorf("unhandled type %v", sfKey))
-			}
-		}
-		fmt.Printf("new key %v (old %v)\n", newKeyValue.Interface(), index)
-	default:
-		fmt.Printf("unhandled type %s\n", currValueType.Kind().String())
 	}
-	return nil, nil
+	return ""
+}
+
+func getPreviousKey(annotation map[string]interface{}, key string) string {
+	orderedKeys := getOrderedKeys(annotation)
+	for i, k := range orderedKeys {
+		if k == key {
+			if i > 0 {
+				return orderedKeys[i-1]
+			}
+		}
+	}
+	return ""
+}
+
+func getGoStruct(annotation map[string]interface{}) interface{} {
+	gostruct, ok := annotation[goStruct]
+	if ok {
+		return gostruct
+	}
+	return nil
 }

--- a/pkg/xpath/navigator/navigator_test.go
+++ b/pkg/xpath/navigator/navigator_test.go
@@ -17,55 +17,31 @@ package navigator
 import (
 	"github.com/openconfig/goyang/pkg/yang"
 	"github.com/stretchr/testify/assert"
+	"reflect"
 	"testing"
 )
 
-func Test_orderKeysWithListKeys(t *testing.T) {
-	entriesMap := map[string]*yang.Entry{
-		"key1": {
-			Name: "e1",
-		},
-		"key2": {
-			Name: "e2",
-		},
-		"key10": {
-			Name: "e10",
-		},
-		"key0": {
-			Name: "e0",
-		},
-	}
-	listKeysStr := "key1 key2"
-	otherKeys, listKeys := orderKeys(entriesMap, listKeysStr)
-	assert.ElementsMatch(t, []string{"key0", "key10"}, otherKeys)
-	assert.ElementsMatch(t, []string{"key1", "key2"}, listKeys)
+type testStruct struct {
+	A string `path:"a" module:"onf-test1"`
+	B int    `path:"b" module:"onf-test1"`
 }
 
-func Test_orderKeysNoList(t *testing.T) {
-	entriesMap := map[string]*yang.Entry{
-		"key0": {
-			Name: "e0",
-		},
-		"key1": {
-			Name: "e1",
-		},
-		"key2": {
-			Name: "e2",
-		},
-		"key10": {
-			Name: "e10",
-		},
-	}
-	listKeysStr := ""
-	otherKeys, listKeys := orderKeys(entriesMap, listKeysStr)
-	assert.ElementsMatch(t, []string{"key0", "key1", "key2", "key10"}, otherKeys)
-	assert.ElementsMatch(t, []string{}, listKeys)
-}
+func Test_processStruct(t *testing.T) {
+	// TODO: create a more detailed struct val and a YANG Entry that can be passed to this
 
-func Test_orderKeysNoKeysButListIsError(t *testing.T) {
-	entriesMap := map[string]*yang.Entry{}
-	listKeysStr := "key1"
-	otherKeys, listKeys := orderKeys(entriesMap, listKeysStr)
-	assert.ElementsMatch(t, []string{}, otherKeys)
-	assert.ElementsMatch(t, []string{"key1"}, listKeys)
+	entry := &yang.Entry{
+		Name: "test1",
+	}
+
+	testStruct1 := &testStruct{
+		A: "test1",
+		B: 10,
+	}
+
+	testStructValue := reflect.ValueOf(testStruct1)
+	t.Skip()
+
+	result := processStruct(testStructValue, "test1", entry)
+	assert.NotNil(t, result)
+
 }


### PR DESCRIPTION
Refactored to zip together all of the meta-data with the values data at the time of creating the `YangNodeNavigator` and it makes it much easier to navigate through this signle tree later